### PR TITLE
Added DWARGS to start.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ helm install w2bro/direwolf
 | `ADEVICE`   | No  | Override Direwolf's ADEVICE for digipeater, default is `stdin null` for receive-only igate |
 | `FREQUENCY` | No  | Override `rtl_fm` input frequency, default `144.39M` North America APRS |
 | `DW_STANDALONE` | No | Set to any value to disable rtl_fm, useful in digipeater applications. Must also set `ADEVICE` |
+| `DWARGS` | No | Set to add/pass any arguments to the direwolf executable, example `-t 0` for no color logs |
 
 ## Example Usage
 

--- a/start.sh
+++ b/start.sh
@@ -33,11 +33,11 @@ fi
 # Optionally start direwolf without rtl_fm as input
 if [ -n "$DW_STANDALONE" ]; then
   if [ -n "$ADEVICE" ]; then
-    direwolf -c direwolf.conf
+    direwolf $DWARGS -c direwolf.conf
   else
     echo "DW_STANDALONE requires ADEVICE also be defined."
     exit 4
   fi
 else
-  rtl_fm -f $FREQUENCY | direwolf -c direwolf.conf
+  rtl_fm -f $FREQUENCY | direwolf $DWARGS -c direwolf.conf
 fi


### PR DESCRIPTION
Added `DWARGS` to `start.sh`, so that one can pass arguments to the direwolf executable. I needed to pass `-t 0` since I didn't need the colors in my logs. Hope it helps! Thanks :)
