### PR TITLE
reduce build size, run a docker user, give it a place to log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM debian:buster-slim as base
-RUN mkdir -p /etc/direwolf
 RUN apt-get update && apt-get -y dist-upgrade \
  && apt-get install -y \
     rtl-sdr \
-    libasound2-dev \
-    libusb-1.0-0-dev \
+    libasound2 \
+    libusb-1.0-0 \
+    libhamlib2 \
+    libgps23 \
  && rm -rf /var/lib/apt/lists/*
 
 FROM base as builder
@@ -12,6 +13,10 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     git \
     cmake \
+    libasound2-dev \
+    libusb-1.0-0-dev \
+    libhamlib-dev \
+    libgps-dev \   
  && rm -rf /var/lib/apt/lists/*
 
 RUN git clone "https://github.com/wb2osz/direwolf.git" /tmp/direwolf \
@@ -21,11 +26,11 @@ RUN git clone "https://github.com/wb2osz/direwolf.git" /tmp/direwolf \
   && make -j4 \
   && make DESTDIR=/target install \
   && make install-conf \
-  && find /target/bin -type f -exec strip -p --strip-debug {} \;
+  && find /target/usr/local/bin/ -type f -exec strip -p --strip-debug {} \;
 
 FROM base
-COPY --from=builder /target/ /usr/local/
-COPY --from=builder /etc/udev/rules.d/99-direwolf-cmedia.rules /etc/udev/rules.d/99-direwolf-cmedia.rules
+COPY --from=builder /target/usr/local/bin /usr/local/bin
+COPY --from=builder /target/etc/udev/rules.d/99-direwolf-cmedia.rules /etc/udev/rules.d/99-direwolf-cmedia.rules
 
 ENV CALLSIGN "N0CALL"
 ENV PASSCODE "-1"
@@ -34,7 +39,14 @@ ENV FREQUENCY "144.39M"
 ENV COMMENT "Direwolf in Docker w2bro/direwolf"
 ENV SYMBOL "igate"
 
+RUN mkdir -p /etc/direwolf
+RUN mkdir -p /var/log/direwolf
+RUN addgroup -gid 242 direwolf && adduser -q -uid 242 -gid 242 --no-create-home --disabled-login --gecos "" direwolf 
 COPY start.sh direwolf.conf /etc/direwolf/
+RUN chown 242.242 -R /etc/direwolf
+RUN chown 242.242 -R /var/log/direwolf
+
+USER direwolf 
 WORKDIR /etc/direwolf
 
 CMD ["/bin/bash", "/etc/direwolf/start.sh"]


### PR DESCRIPTION
forked your work and would like to push these optimizations back into yours, taking the dev libraries out of the base image has reduced the compressed image from ~45MB on yours to ~28MB on mine.. I also changed it so direwolf does not run as root, and gave it a place to stash logs into.